### PR TITLE
Changed LCD data connection to VIA PORTB

### DIFF
--- a/src/include/config.h
+++ b/src/include/config.h
@@ -23,8 +23,8 @@
 #define ROM_END	 	0xFFFF
 
 // For use when LCD simulated connection to VIA, select between data on PORTA or PORTB
-#define LCD_PORTA
-// #define LCD_PORTB
+// #define LCD_PORTA
+#define LCD_PORTB
 
 #define LCD_SW_RS_RW
 


### PR DESCRIPTION
The README states "By default, the LCD is connected to the VIA on PORTB" however it was actually connected on PORTA by default. 

Changing it to PORTB as this is what Ben Eater uses in his videos.